### PR TITLE
Halt compiled as breakpoint

### DIFF
--- a/src/AST-Core/OCMethodNode.class.st
+++ b/src/AST-Core/OCMethodNode.class.st
@@ -657,6 +657,12 @@ OCMethodNode >> semanticScope: aSemanticScope [
 	self compilationContext semanticScope: aSemanticScope
 ]
 
+{ #category : 'as yet unclassified' }
+OCMethodNode >> sendNodesWithSelector: aSelector [
+
+	^ self sendNodes select: [ :node | node selector = aSelector ]
+]
+
 { #category : 'accessing' }
 OCMethodNode >> source [
 	^source

--- a/src/OpalCompiler-Core/OCCompilationContext.class.st
+++ b/src/OpalCompiler-Core/OCCompilationContext.class.st
@@ -160,6 +160,11 @@ OCCompilationContext class >> optionHaltAsBreakpoint [
 	^ self readDefaultOption: #optionHaltAsBreakpoint
 ]
 
+{ #category : 'as yet unclassified' }
+OCCompilationContext class >> optionHaltAsBreakpoint: aBoolean [ 
+	^ self writeDefaultOption: #optionHaltAsBreakpoint value: aBoolean
+]
+
 { #category : 'options - settings API' }
 OCCompilationContext class >> optionInlineAndOr [
 	^ self readDefaultOption: #optionInlineAndOr

--- a/src/OpalCompiler-Core/OCCompilationContext.class.st
+++ b/src/OpalCompiler-Core/OCCompilationContext.class.st
@@ -155,6 +155,11 @@ OCCompilationContext class >> optionConstantBlockClosure: aBoolean [
 	^ self writeDefaultOption: #optionConstantBlockClosure value: aBoolean
 ]
 
+{ #category : 'as yet unclassified' }
+OCCompilationContext class >> optionHaltAsBreakpoint [
+	^ self readDefaultOption: #optionHaltAsBreakpoint
+]
+
 { #category : 'options - settings API' }
 OCCompilationContext class >> optionInlineAndOr [
 	^ self readDefaultOption: #optionInlineAndOr
@@ -336,6 +341,7 @@ OCCompilationContext class >> optionsDescription [
 	(- optionParseErrors 					'Parse syntactically wrong code (interactive and non-interactive')
 	(- optionParseErrorsNonInteractiveOnly 	'Parse syntactically wrong code in non-interactive mode only')
 	(- optionSkipSemanticWarnings 		'Do not warn about semantic problems (e.g. undeclared vars). Used for syntax highlight parsing')
+	(- optionHaltAsBreakpoint 		'Compile message send #halt as breakpoint')
 
 	)
 ]
@@ -522,6 +528,11 @@ OCCompilationContext >> optionCleanBlockClosure [
 { #category : 'options' }
 OCCompilationContext >> optionConstantBlockClosure [
 	^ options includes: #optionConstantBlockClosure
+]
+
+{ #category : 'as yet unclassified' }
+OCCompilationContext >> optionHaltAsBreakpoint [
+	^ options includes: #optionHaltAsBreakpoint
 ]
 
 { #category : 'options' }

--- a/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
@@ -637,12 +637,17 @@ OCIRBytecodeGenerator >> send: selector [
 	| nArgs |
 	nArgs := selector numArgs.
 	stack pop: nArgs.
+
+	selector = #halt ifTrue: [
+			"1 halt."
+			^ self ].
+
 	(compilationContext optionOptimiseSpecialSends and: [
 		 self encoderClass specialSelectors includes: selector ]) ifTrue: [
-		^ encoder
-			  genSendSpecial:
-			  (self encoderClass specialSelectors indexOf: selector)
-			  numArgs: nArgs ].
+			^ encoder
+				  genSendSpecial:
+				  (self encoderClass specialSelectors indexOf: selector)
+				  numArgs: nArgs ].
 	encoder genSend: (self literalIndexOf: selector) numArgs: nArgs
 ]
 

--- a/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
@@ -638,9 +638,10 @@ OCIRBytecodeGenerator >> send: selector [
 	nArgs := selector numArgs.
 	stack pop: nArgs.
 
-	selector = #halt ifTrue: [
-			"1 halt."
-			^ self ].
+	(compilationContext optionHaltAsBreakpoint and: [ selector = #halt ])
+		ifTrue: [
+				"Avoid message send, later it will put a breakpoint instead"
+				^ self ].
 
 	(compilationContext optionOptimiseSpecialSends and: [
 		 self encoderClass specialSelectors includes: selector ]) ifTrue: [

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -592,6 +592,9 @@ OpalCompiler >> install [
 
 	class instanceSide noteCompilationOf: method meta: class isClassSide.
 
+	"1halt."
+	self installBreakpointsOnHalts: method ast.
+
 	^ method
 ]
 
@@ -600,6 +603,15 @@ OpalCompiler >> install: aSource [
 
 	self source: aSource.
 	^ self install
+]
+
+{ #category : 'as yet unclassified' }
+OpalCompiler >> installBreakpointsOnHalts: methodNode [
+
+	| halts |
+	halts := methodNode sendNodesWithSelector: #halt.
+	halts do: [ :halt |
+		DebugPointManager installNew: BreakDebugPoint on: halt receiver ]
 ]
 
 { #category : 'testing' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -592,8 +592,8 @@ OpalCompiler >> install [
 
 	class instanceSide noteCompilationOf: method meta: class isClassSide.
 
-	"1halt."
-	self installBreakpointsOnHalts: method ast.
+	compilationContext optionHaltAsBreakpoint ifTrue: [ 
+		self installBreakpointsOnHalts: method ast ].
 
 	^ method
 ]

--- a/src/OpalCompiler-Tests/MockForCompilation.class.st
+++ b/src/OpalCompiler-Tests/MockForCompilation.class.st
@@ -12,6 +12,10 @@ Class {
 	#tag : 'FromOld'
 }
 
+{ #category : 'as yet unclassified' }
+MockForCompilation >> foo [ <compilerOptions: #(+ optionHaltAsBreakpoint)> 1halt
+]
+
 { #category : 'accessing' }
 MockForCompilation >> var1 [
 

--- a/src/OpalCompiler-Tests/MockForCompilation.class.st
+++ b/src/OpalCompiler-Tests/MockForCompilation.class.st
@@ -12,10 +12,6 @@ Class {
 	#tag : 'FromOld'
 }
 
-{ #category : 'as yet unclassified' }
-MockForCompilation >> foo [ <compilerOptions: #(+ optionHaltAsBreakpoint)> 1halt
-]
-
 { #category : 'accessing' }
 MockForCompilation >> var1 [
 

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -145,6 +145,18 @@ OpalCompilerTest >> testCompilerUsingCleanBlockClosureHasBlockAsLiteral [
 ]
 
 { #category : 'tests - bindings' }
+OpalCompilerTest >> testEvaluateHalt [
+
+	| result method |
+	OpalCompiler new
+		class: MockForCompilation;
+		install: 'foo 2halt'.
+	method := MockForCompilation >> #foo.
+	result := method valueWithReceiver: nil.
+	self assert: result equals: nil
+]
+
+{ #category : 'tests - bindings' }
 OpalCompilerTest >> testEvaluateWithBindings [
 	| result |
 	result := OpalCompiler new 

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -91,6 +91,37 @@ OpalCompilerTest >> testCompileFromText [
 	self assert: result sourceCode equals: source asString
 ]
 
+{ #category : 'tests - bindings' }
+OpalCompilerTest >> testCompileHalt [
+
+	| method |
+	OpalCompiler new
+		class: MockForCompilation;
+		install: 'foo <compilerOptions: #(- optionHaltAsBreakpoint)> 1halt'.
+	method := MockForCompilation >> #foo.
+
+	self assert: (method bytecodes first: 2) equals: #[ 
+		81  "push constant"
+		128 "send: halt"
+	]
+]
+
+{ #category : 'tests - bindings' }
+OpalCompilerTest >> testCompileHaltAsBreakpoint [
+
+	| method |
+	OpalCompiler new
+		class: MockForCompilation;
+		install: 'foo <compilerOptions: #(+ optionHaltAsBreakpoint)> 1halt'.
+	method := MockForCompilation >> #foo.
+
+	self assert: (method bytecodes first: 3) equals: #[ 
+		32  "push a BreakDebugPoint"
+		82  "push thisContext"
+		145 "send: hitWithContext:"
+	]
+]
+
 { #category : 'tests' }
 OpalCompilerTest >> testCompileSource [
 	| source result |
@@ -142,18 +173,6 @@ OpalCompilerTest >> testCompilerUsingCleanBlockClosureHasBlockAsLiteral [
 
 	self assert: method literals second isEmbeddedBlock.
 	self assert: method literals second class equals: CleanBlockClosure
-]
-
-{ #category : 'tests - bindings' }
-OpalCompilerTest >> testEvaluateHalt [
-
-	| result method |
-	OpalCompiler new
-		class: MockForCompilation;
-		install: 'foo <compilerOptions: #(+ optionHaltAsBreakpoint)> 2halt'.
-	method := MockForCompilation >> #foo.
-	result := method valueWithReceiver: nil.
-	self assert: result equals: nil
 ]
 
 { #category : 'tests - bindings' }

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -150,7 +150,7 @@ OpalCompilerTest >> testEvaluateHalt [
 	| result method |
 	OpalCompiler new
 		class: MockForCompilation;
-		install: 'foo 2halt'.
+		install: 'foo <compilerOptions: #(+ optionHaltAsBreakpoint)> 2halt'.
 	method := MockForCompilation >> #foo.
 	result := method valueWithReceiver: nil.
 	self assert: result equals: nil

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -7,6 +7,13 @@ Class {
 }
 
 { #category : 'tests - bindings' }
+OpalCompilerTest >> tearDown [
+
+	MockForCompilation removeSelector: #foo.
+	super tearDown
+]
+
+{ #category : 'tests - bindings' }
 OpalCompilerTest >> testArrayBindingsWithUppercaseNameDoOverwriteGlobals [
 	| result |
 	result := Smalltalk compiler
@@ -173,6 +180,33 @@ OpalCompilerTest >> testCompilerUsingCleanBlockClosureHasBlockAsLiteral [
 
 	self assert: method literals second isEmbeddedBlock.
 	self assert: method literals second class equals: CleanBlockClosure
+]
+
+{ #category : 'tests - bindings' }
+OpalCompilerTest >> testEvaluateHalt [
+
+	| method |
+	OpalCompiler new
+		class: MockForCompilation;
+		install: 'foo <compilerOptions: #(- optionHaltAsBreakpoint)> 1halt'.
+	method := MockForCompilation >> #foo.
+
+	self should: [ method valueWithReceiver: nil ] raise: Halt
+]
+
+{ #category : 'tests - bindings' }
+OpalCompilerTest >> testEvaluateHaltAsBreakpoint [
+
+	| method |
+	OpalCompiler new
+		class: MockForCompilation;
+		install: 'foo <compilerOptions: #(+ optionHaltAsBreakpoint)> 1halt'.
+	method := MockForCompilation >> #foo.
+
+	self
+		should: [ method valueWithReceiver: nil ]
+		raise: Break
+		withExceptionDo: [ :ex | self assert: ex class equals: Break "It is not from the superclass Halt" ]
 ]
 
 { #category : 'tests - bindings' }


### PR DESCRIPTION
This is an experiment to compile message `x halt` as a breakpoint on the node `x`.

This includes:
- Changes in the compiler to
  - Ignore the message send `halt` (do not generate the bytecode)
  - Insert a breakpoint on the receiver
- We also added a setting to toggle this behaviour

_Made on Sprint with @luc-raz_

---------

## What's missing?

- Now it only works for `halt`, but there are other methods (`haltOnce`, `haltIf`, ...). We should implement their semantics in a breakpoint way
- If you remove the breakpoint, the code keeps with a `halt` that never hits. We should catch this case when a breakpoint is removed and compile the halt in that case.